### PR TITLE
Added commit message wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,16 @@ Example with range
 
     ./git-graph -r a51eced..HEAD | dot -Tps -o graph.ps
 
+Example with commit messages and message wrapping
+
+    ./git-graph -mwc 35 | dot -Tps -o graph.ps
+
 ### Parameters
-* **-x**: to print debug output to stderr
-* **-m**: show commit messages in nodes
-* **-r range**: to get a specific range of the repository. See [here](http://git-scm.com/book/en/Git-Tools-Revision-Selection#Commit-Ranges)
+* **-x**: To print debug output to stderr.
+* **-m**: Show commit messages in nodes.
+* **-w**: Wrap commit messages.
+* **-c column**: Column at which to start wrapping commit messages.
+* **-r range**: To get a specific range of the repository. See [here](http://git-scm.com/book/en/Git-Tools-Revision-Selection#Commit-Ranges)
 
 # Example Graph
 ![alt text](images/example.gif)

--- a/git-graph
+++ b/git-graph
@@ -5,6 +5,7 @@ import re
 import hashlib
 import sys
 import argparse
+import textwrap
 
 # colors
 COLOR_NODE = "cornsilk"
@@ -24,15 +25,20 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument("-x", "--debug", dest="debug", action="store_true", help="Show debug messages on stderr")
 parser.add_argument("-m", "--messages", dest="messages", action="store_true", help="Show commit messages in node" )
+parser.add_argument("-w", "--wrap", dest="wrapMessages", action="store_true", help="Wrap commit messages" )
+parser.add_argument("-c", "--columns", dest="wrapLimit", type=int, default=60, action="store", help="Wrap messages at column" )
 parser.add_argument("-r", "--range", help="git commit range" )
 
 args = parser.parse_args()
 debug = args.debug
 
+if args.wrapLimit < 1:
+    parser.print_help()
+    sys.exit(1)
+
 def log(message):
     if debug:
         print(message, file=sys.stderr)
-
 
 revRange = ""
 if args.range:
@@ -97,7 +103,9 @@ for line in lines:
         labelExt = ""
         nodeMessage = ""
         if args.messages:
-            nodeMessage = "\n" + message.replace("\"", "'");
+            if args.wrapMessages:
+               message = textwrap.fill(message, args.wrapLimit).replace("\n", "\\n")
+            nodeMessage = "\n" + message.replace("\"", "'")
         if commitHash in predefinedNodeColor:
             labelExt = "\\nSTASH INDEX"
             nodeColor = predefinedNodeColor[commitHash]


### PR DESCRIPTION
Hello,
I'm in the terrible habit of writing over-long commit messages. This makes the graphs output from your (excellent) tool difficult to visually parse (or even load.) I've added an option to automatically wrap the commit messages at a given column.
Regards,
Sam